### PR TITLE
Takes the container's parent padding into account

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Update your webpack config loaders
 
 Import `VideoPlayer` into your component.
 ```
-import VideoPlayer from '@articulate/orson/lib/VideoPlayer';
+import VideoPlayer from '@articulate/orson';
 
 <VideoPlayer>
   <source src="__path_to_mp4__" type="video/mp4" />
@@ -42,4 +42,3 @@ These props are not required, but available if needed.
 
 - `aspectRatio` - a number, defualts to `(9 / 16)`
 - `options` - video.js options used to create the player object.  See [Videojs Options](http://docs.videojs.com/docs/guides/options.html#component-options)
-

--- a/lib/VideoPlayer.js
+++ b/lib/VideoPlayer.js
@@ -5,6 +5,7 @@ class VideoPlayer extends React.Component {
   constructor() {
     super();
     this.state = {};
+    this.setDimensions = this.setDimensions.bind(this);
   }
 
   static defaultProps = {
@@ -34,7 +35,7 @@ class VideoPlayer extends React.Component {
   }
 
   componentDidMount() {
-    window.addEventListener('resize', this.setDimensions.bind(this));
+    window.addEventListener('resize', this.setDimensions);
     this.player = vjs(this.video, this.props.options);
     this.setDimensions();
   }
@@ -45,6 +46,15 @@ class VideoPlayer extends React.Component {
 
   getBoundingRect() {
     return this.container.parentNode.getBoundingClientRect();
+  }
+
+  getParentPadding() {
+    let computedStyle = window.getComputedStyle(this.container.parentNode, null);
+    const getProperty = (cs, value) => parseInt(cs.getPropertyValue(value), 10) || 0;
+    return {
+      top: getProperty(computedStyle, 'padding-top'),
+      bottom: getProperty(computedStyle, 'padding-bottom')
+    };
   }
 
   render() {
@@ -58,17 +68,19 @@ class VideoPlayer extends React.Component {
   }
 
   setDimensions() {
-    const dimensions = this.getBoundingRect();
+    let {width: parentWidth, height: parentHeight} = this.getBoundingRect();
+    const padding = this.getParentPadding();
+    parentHeight = parentHeight - padding.top - padding.bottom;
     const aspectRatio = this.props.aspectRatio;
     let width, height;
-    if ((dimensions.width * aspectRatio <= dimensions.height) ||
+    if ((parentWidth * aspectRatio <= parentHeight) ||
       (this.props.fullWidthAt && window.innerWidth < this.props.fullWidthAt)
     ) {
-      width = dimensions.width;
-      height = dimensions.width * aspectRatio;
+      width = parentWidth;
+      height = parentWidth * aspectRatio;
     } else {
-      height = dimensions.height;
-      width = dimensions.height * (1 / aspectRatio);
+      height = parentHeight;
+      width = parentHeight * (1 / aspectRatio);
     }
     this.setState({ dimensions: { width, height } });
   }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "prebuild": "npm run clean",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "main": "lib/VideoPlayer",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/articulate/orson.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@articulate/orson",
-  "version": "0.0.22",
+  "version": "0.1.0",
   "description": "React video component with some Articulate flavor",
   "scripts": {
     "build": "babel lib -d dist",


### PR DESCRIPTION
Allows to specify a padding-top or padding-bottom in the container node
that will be taken into account when setting dimensions.