### PR TITLE
Precompilation 

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,1 +1,4 @@
-{ "stage": 0 }
+{
+  "presets": ["es2015", "react"],
+  "plugins": ["transform-class-properties"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 npm-debug.log
+dist

--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,1 @@
-node_modules/
+.gitignore

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # Orson
 
-An Articulate flavored react component video player.
+An Articulate flavored React component video player.
 
 ## Install
+
 `npm install @articulate/orson`
 
 ## Usage
 Import the stylesheets
+
 ```html
 <link rel="stylesheet" src="/path/to/videojs.css" />
 <link rel="stylesheet" src="node_modules/@articulate/orson/dist/VideoPlayer.css" />
@@ -19,7 +21,8 @@ or, if using webpack and sass-loader on your project
 ```
 
 Import `VideoPlayer` into your component.
-```
+
+```jsx
 import VideoPlayer from '@articulate/orson';
 
 <VideoPlayer>
@@ -31,8 +34,35 @@ import VideoPlayer from '@articulate/orson';
 </VideoPlayer>
 ```
 
-## Available Props
-These props are not required, but available if needed.
+## API
 
-- `aspectRatio` - a number, defualts to `(9 / 16)`
-- `options` - video.js options used to create the player object.  See [Videojs Options](http://docs.videojs.com/docs/guides/options.html#component-options)
+### Props
+
+- **aspectRatio** (number, default: 9/16) Desired ratio between width and height.
+- **fullWidthAt** (number) Specifies a screen breakpoint under which the player will try to use the entire width of the parent.
+- **options** (object) Options passed to video.js ([see reference][vjs-options])
+
+### Methods
+
+You'll need to capture a ref to the VideoPlayer instance for this.
+
+- **.setDimensions()** calculates and sets the ideal dimensions for the video player.
+- **.snapshot()** creates a base64 image of the video in png.
+
+### Properties
+
+You'll need to capture a ref to the VideoPlayer instance for this.
+
+- **.player** gets the video.js player reference. You can then [use any of the video.js player API's methods][vjs-player-api]
+
+## Upgrading to 1.0.
+
+The following steps need to be performed if using a version pre-1.0
+
+1. Remove webpack configuration for this plugin.
+This plugin used to require setting up exceptions in webpack's config loaders section, which is no longer needed.
+1. Import the CSS. Previously, stylesheets would be imported automatically with sass-loader. That's no longer the case.
+1. Change imports from `import VideoPlayer from '@articulate/orson/lib/VideoPlayer'` to `import VideoPlayer from '@articulate/orson'`
+
+  [vjs-options]: http://docs.videojs.com/docs/guides/options.html#component-options
+  [vjs-player-api]: http://docs.videojs.com/docs/api/player.html#methods

--- a/README.md
+++ b/README.md
@@ -6,23 +6,17 @@ An Articulate flavored react component video player.
 `npm install @articulate/orson`
 
 ## Usage
-Orson requires the installation of [video.js](http://videojs.com/).
-`npm install video.js`
-
-Update your webpack config loaders
+Import the stylesheets
+```html
+<link rel="stylesheet" src="/path/to/videojs.css" />
+<link rel="stylesheet" src="node_modules/@articulate/orson/dist/VideoPlayer.css" />
 ```
-{
-  test: /\.js$/,
-  loader: 'babel-loader',
-  include: path.join(__dirname, 'node_modules', '@articulate', 'orson')
-},
-{
-  test: /\.eot$/,
-  loader: 'url-loader'
-}
-```
-> Note: you may need to npm install the `url-loader` and it's dependent `file-loader`.
 
+or, if using webpack and sass-loader on your project
+
+```scss
+@import "~@articulate/orson/lib/index.webpack";
+```
 
 Import `VideoPlayer` into your component.
 ```

--- a/lib/VideoPlayer.js
+++ b/lib/VideoPlayer.js
@@ -1,5 +1,5 @@
 const {Component, PropTypes} = require('react');
-const vjs = require('video.js/dist/alt/video.novtt');
+const vjs = require('video.js');
 
 class VideoPlayer extends Component {
   constructor() {

--- a/lib/VideoPlayer.js
+++ b/lib/VideoPlayer.js
@@ -1,7 +1,7 @@
-import vjs from 'video.js/dist/alt/video.novtt';
-import './VideoPlayer.scss';
+const {Component, PropTypes} = require('react');
+const vjs = require('video.js/dist/alt/video.novtt');
 
-class VideoPlayer extends React.Component {
+class VideoPlayer extends Component {
   constructor() {
     super();
     this.state = {};
@@ -21,18 +21,18 @@ class VideoPlayer extends React.Component {
         }
       }
     }
-  }
+  };
 
   static propTypes = {
-    aspectRatio: React.PropTypes.number,
-    fullWidthAt: React.PropTypes.number,
-    options: React.PropTypes.shape({
-      bigPlayButton: React.PropTypes.bool,
-      preload: React.PropTypes.string,
-      controls: React.PropTypes.bool,
-      controlBar: React.PropTypes.object
+    aspectRatio: PropTypes.number,
+    fullWidthAt: PropTypes.number,
+    options: PropTypes.shape({
+      bigPlayButton: PropTypes.bool,
+      preload: PropTypes.string,
+      controls: PropTypes.bool,
+      controlBar: PropTypes.object
     })
-  }
+  };
 
   componentDidMount() {
     window.addEventListener('resize', this.setDimensions);
@@ -103,4 +103,4 @@ class VideoPlayer extends React.Component {
   }
 }
 
-export default VideoPlayer;
+module.exports = VideoPlayer;

--- a/lib/VideoPlayer.scss
+++ b/lib/VideoPlayer.scss
@@ -1,6 +1,3 @@
-$icon-font-path: '~videojs-font/fonts';
-@import '~video.js/src/css/vjs';
-
 $primary-foreground-color: #fff;
 $primary-background-color: rgba(0, 0, 0, .3);
 $slider-bg-color: #fff;

--- a/lib/index.webpack.scss
+++ b/lib/index.webpack.scss
@@ -1,0 +1,3 @@
+$icon-font-path: '~videojs-font/fonts';
+@import '~video.js/src/css/vjs';
+@import './VideoPlayer';

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "react": "^15.0.0"
   },
   "dependencies": {
-    "video.js": "^5.10.4"
+    "video.js": "^5.12.0"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0"

--- a/package.json
+++ b/package.json
@@ -3,12 +3,15 @@
   "version": "0.5.1",
   "description": "React video component with some Articulate flavor",
   "scripts": {
-    "build": "babel lib -d dist",
     "clean": "rm -rf dist",
     "prebuild": "npm run clean",
+    "sass": "node-sass lib/VideoPlayer.scss -o dist",
+    "babel": "babel lib -d dist",
+    "build": "npm run babel && npm run sass",
+    "prepublish": "npm run build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "main": "lib/VideoPlayer",
+  "main": "dist/VideoPlayer",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/articulate/orson.git"
@@ -24,19 +27,18 @@
   },
   "homepage": "https://github.com/articulate/orson#readme",
   "devDependencies": {
-    "autoprefixer-loader": "^3.2.0",
-    "babel-cli": "^6.10.1",
+    "babel-cli": "^6.14.0",
     "babel-core": "^6.9.1",
+    "babel-plugin-transform-class-properties": "^6.11.5",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.5.0",
-    "css-loader": "^0.23.1",
-    "file-loader": "^0.9.0",
     "node-sass": "^3.8.0",
-    "react-dom": "^15.1.0",
-    "react": "^15.1.0",
-    "sass-loader": "^4.0.0",
-    "style-loader": "^0.13.1",
-    "url-loader": "^0.5.7",
+    "react": "^15.0.0"
+  },
+  "dependencies": {
     "video.js": "^5.10.4"
+  },
+  "peerDependencies": {
+    "react": "^0.14.0 || ^15.0.0"
   }
 }


### PR DESCRIPTION
This updates tooling to babel 6, and makes it so the library is compiled before pushing to npm.

This makes it so that the client doesn't need to configure webpack or be in the same version of babel to use this version.

This also uses the latest video.js which removes webpacks warning about using a prebuilt file.

```
9:480-487 This seems to be a pre-built javascript file. Though this is
possible, it's not recommended. Try to require the original source to
get better results.
 @ ../orson/~/video.js/dist/alt/video.novtt.js 9:480-487
```