### PR TITLE
seek to beginning of video when end is reached

### DIFF
--- a/lib/VideoPlayer.js
+++ b/lib/VideoPlayer.js
@@ -36,7 +36,12 @@ class VideoPlayer extends React.Component {
 
   componentDidMount() {
     window.addEventListener('resize', this.setDimensions);
-    this.player = vjs(this.video, this.props.options);
+    let player = this.player = vjs(this.video, this.props.options);
+    player.on('ended', () => {
+      player.posterImage.show();
+      player.bigPlayButton.show();
+      player.currentTime(0);
+    });
     this.setDimensions();
   }
 


### PR DESCRIPTION
![cop out](http://www.the-other-view.com/images/copoutlogo.jpg)

resolves this issue: https://www.pivotaltracker.com/story/show/127989673

it is difficult to determine when the last frame of an http stream begins due to the variable framerate of an h.264 video.  Video snapshots must be taken no later than when the last frame begins or the resulting snapshot will be an image with 0 bytes.  This is an attempt to prevent snapshots being taken at the end of a video, doing so will require more effort to understand how to calculate the time the last frame begins.