### PR TITLE
Remove crossOrigin prop

### DIFF
--- a/lib/VideoPlayer.js
+++ b/lib/VideoPlayer.js
@@ -65,7 +65,7 @@ class VideoPlayer extends React.Component {
   render() {
     return (
       <div className="videoContainer" style={this.state.dimensions} ref={(node) => { this.container = node; }}>
-        <video className="video-js vjs-default-skin" ref={(node) => { this.video = node; }} crossOrigin='anonymous'>
+        <video className="video-js vjs-default-skin" ref={(node) => { this.video = node; }}>
           {this.props.children}
         </video>
       </div>


### PR DESCRIPTION
![crossorigin](http://vignette4.wikia.nocookie.net/cardfight/images/f/ff/G-FC02-003EN-GR.png/revision/latest?cb=20160105160502)

`CORS` is clearly a foul beast, and since we no longer require it for snapshots (and since it breaks :allthethings: in scorm), we should just not anymore.

ping @pklingem @evilsoft 