### PR TITLE
Adding babelrc to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 .gitignore
+.babelrc


### PR DESCRIPTION
This makes it so `.babelrc` is not copied to the npm package.

This avoids a possible error in babel 5 clients.

ping @jrpz 