### PR TITLE
Fix videojs bad release version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "react": "^15.0.0"
   },
   "dependencies": {
-    "video.js": "^5.12.0"
+    "video.js": "5.12.6"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0"


### PR DESCRIPTION
![](https://media.giphy.com/media/Isizj9SELVf6E/giphy.gif)

Fixes `npm WARN deprecated video.js@5.13.0: Bad release. Please use 5.12` each time we `npm install` - 