### PR TITLE
BYO videojs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ An Articulate flavored React component video player.
 `npm install @articulate/orson`
 
 ## Usage
+
+Bring your own `video.js`, or don't.  Orson will require `video.js` if `videojs` is not globally defined.
+```html
+<script src="http://vjs.zencdn.net/5.11.9/video.js"></script>
+```
+
 Import the stylesheets
 
 ```html

--- a/lib/VideoPlayer.js
+++ b/lib/VideoPlayer.js
@@ -1,5 +1,5 @@
 const {Component, PropTypes} = require('react');
-const vjs = require('video.js');
+const vjs = (typeof videojs === 'function') ? videojs : require('video.js');
 
 class VideoPlayer extends Component {
   constructor() {


### PR DESCRIPTION
We are seeing a number of errors on frontend due to `video.js` attempting to (randomly) load `vtt`.  To mitigate we will load `video.js` from a CDN which will globally define `videojs`.

If defined, Orson will use the global `video.js`.  If not defined, it will require `video.js` from `node_modules`.

@jeduan @spencerfdavis @evilsoft thoughts on this one?