### PR TITLE
Remove black pixel glitch on progress bar hover

### DIFF
--- a/lib/VideoPlayer.scss
+++ b/lib/VideoPlayer.scss
@@ -109,10 +109,12 @@ $slider-height: 0.2em;
 
       .vjs-mouse-display {
         height: $slider-height;
+        background: #fff;
       }
 
       .vjs-play-progress {
         height: $slider-height;
+        background: rgb(165, 165, 165);
 
         // Scrubber grabber sizing (circle)
         &::before {


### PR DESCRIPTION
Removes the black scrubbing pixel, which always felt glitchy to me, when hovering over the white disc progress indicator. Here's how it looks today (zoomed):

![screen shot 2017-07-21 at 10 02 02 am](https://user-images.githubusercontent.com/550256/28466860-cbe666f8-6dfb-11e7-8352-a371a4ef959b.png)

Here's the experience before:
![](http://drops.articulate.com/LXKQj9/1ww8l1Dy+)

Here's how it looks with my change:
![](http://drops.articulate.com/URroMR/4CRFwRYf+)

The white scrubbing indicator blends perfectly into the white disc progress indicator and stands out nicely on the past and future areas of the progress bar.