### PR TITLE
Remove usage of `React.PropTypes` and use `prop-types` package

### DIFF
--- a/lib/VideoPlayer.js
+++ b/lib/VideoPlayer.js
@@ -1,4 +1,5 @@
-const {Component, PropTypes} = require('react');
+const {Component} = require('react');
+const {PropTypes} = require('prop-types');
 const vjs = require('video.js');
 
 class VideoPlayer extends Component {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react": "^15.0.0"
   },
   "dependencies": {
+    "prop-types": "^15.6.2",
     "video.js": "5.12.6"
   },
   "peerDependencies": {


### PR DESCRIPTION
In preparation for [upgrading Rise to React 16](https://github.com/articulate/rise-runtime/issues/2458), I've removed our usage of `React.PropTypes` and added the `prop-types` package instead.

This is necessary so that I can change the React peer dependency here to allow for 15+.

Note that [the documentation on the `prop-types` package](https://www.npmjs.com/package/prop-types#how-to-depend-on-this-package) recommends that `prop-types` be in `dependencies` rather than `peerDependencies`, even for libraries.