### PR TITLE
IE11 bug: use rem units instead of em units in control bar icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2019-03-27
+
+### Bug fixes
+* Use `rem` instead of `em` units in control bar icons, fixing IE11 issue
+
 ## [2.0.0] - 2019-03-26
 
 ### Changed

--- a/lib/VideoPlayer.scss
+++ b/lib/VideoPlayer.scss
@@ -124,7 +124,7 @@ $primary-background-color: rgba(0, 0, 0, 0.3);
 
 // Control bar icon size & vertical placement
 .vjs-button > .vjs-icon-placeholder::before {
-  font-size: 2.2em;
+  font-size: 2.2rem;
   line-height: 3.5;
 }
 


### PR DESCRIPTION
Before:
<img width="791" alt="orson_20" src="https://user-images.githubusercontent.com/5341795/55090387-6660c080-5085-11e9-827d-75e52071cd0f.png">

After this change:
<img width="783" alt="using_rem_units" src="https://user-images.githubusercontent.com/5341795/55090402-6c56a180-5085-11e9-9aaa-a8ab4ec1af63.png">
