### PR TITLE
Rise com style fixes

### DIFF
--- a/lib/VideoPlayer.js
+++ b/lib/VideoPlayer.js
@@ -12,6 +12,7 @@ export default class VideoPlayer extends Component {
   static get defaultProps() {
     return {
       aspectRatio: 9 / 16,
+      fullWidth: false,
       fullWidthAt: 0,
       options: {
         preload: 'auto',
@@ -29,6 +30,7 @@ export default class VideoPlayer extends Component {
   static get propTypes() {
     return {
       aspectRatio: PropTypes.number,
+      fullWidth: PropTypes.bool,
       fullWidthAt: PropTypes.number,
       options: PropTypes.shape({
         bigPlayButton: PropTypes.bool,
@@ -91,7 +93,9 @@ export default class VideoPlayer extends Component {
     parentHeight = parentHeight - padding.top - padding.bottom;
     const aspectRatio = this.props.aspectRatio;
     let width, height;
-    if ((parentWidth * aspectRatio <= parentHeight) ||
+    if (
+      this.props.fullWidth ||
+      (parentWidth * aspectRatio <= parentHeight) ||
       (this.props.fullWidthAt && window.innerWidth < this.props.fullWidthAt)
     ) {
       width = parentWidth;

--- a/lib/VideoPlayer.scss
+++ b/lib/VideoPlayer.scss
@@ -65,6 +65,21 @@ $primary-background-color: rgba(0, 0, 0, 0.3);
   order: 3;
 }
 
+.vjs-volume-panel.vjs-volume-panel-horizontal {
+  align-items: center;
+
+  & .vjs-volume-control.vjs-control.vjs-volume-horizontal {
+    &, &:hover, .video-js .vjs-volume-panel .vjs-mute-control:hover ~ & {
+      height: auto !important;
+    }
+
+    & .vjs-volume-bar {
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+  }
+}
+
 // Vertical volume container
 .video-js .vjs-volume-vertical {
   background-color: rgba(0, 0, 0, 0.5);


### PR DESCRIPTION
part of https://github.com/articulate/rise.com/issues/541

### Changes:
- Add `fullWidth` flag, in the case where the video should always take the full width of the parent regardless of screen size
- Inline volume was always rendering off center for me (not sure why as this style comes directly from vjs :woman_shrugging:), I added some styles that regrettably wound up in a specificity battle, but as far as I can tell it fixed the issue.