### PR TITLE
Full width, and volume style bug

### DIFF
--- a/lib/VideoPlayer.js
+++ b/lib/VideoPlayer.js
@@ -7,6 +7,8 @@ export default class VideoPlayer extends Component {
     super(...params);
     this.state = {};
     this.setDimensions = this.setDimensions.bind(this);
+    this.shouldBeFullWidth = this.shouldBeFullWidth.bind(this);
+    this.getParentDimensions = this.getParentDimensions.bind(this);
   }
 
   static get defaultProps() {
@@ -64,10 +66,6 @@ export default class VideoPlayer extends Component {
     window.removeEventListener('resize', this.setDimensions);
   }
 
-  getBoundingRect() {
-    return this.container.parentNode.getBoundingClientRect();
-  }
-
   getParentPadding() {
     let computedStyle = window.getComputedStyle(this.container.parentNode, null);
     const getProperty = (cs, value) => parseInt(cs.getPropertyValue(value), 10) || 0;
@@ -75,6 +73,13 @@ export default class VideoPlayer extends Component {
       top: getProperty(computedStyle, 'padding-top'),
       bottom: getProperty(computedStyle, 'padding-bottom')
     };
+  }
+
+  getParentDimensions() {
+    const { width, height } = this.container.parentNode.getBoundingClientRect();
+    const padding = this.getParentPadding();
+    const parentHeight = height - padding.top - padding.bottom;
+    return { parentHeight, parentWidth: width };
   }
 
   render() {
@@ -87,23 +92,23 @@ export default class VideoPlayer extends Component {
     );
   }
 
-  setDimensions() {
-    let { width: parentWidth, height: parentHeight } = this.getBoundingRect();
-    const padding = this.getParentPadding();
-    parentHeight = parentHeight - padding.top - padding.bottom;
-    const aspectRatio = this.props.aspectRatio;
-    let width, height;
-    if (
-      this.props.fullWidth ||
+  shouldBeFullWidth() {
+    const { aspectRatio, fullWidth, fullWidthAt } = this.props;
+    const { parentWidth, parentHeight } = this.getParentDimensions();
+
+    return (
+      fullWidth ||
       (parentWidth * aspectRatio <= parentHeight) ||
-      (this.props.fullWidthAt && window.innerWidth < this.props.fullWidthAt)
-    ) {
-      width = parentWidth;
-      height = parentWidth * aspectRatio;
-    } else {
-      height = parentHeight;
-      width = parentHeight * (1 / aspectRatio);
-    }
+      (fullWidthAt && window.innerWidth < fullWidthAt)
+    );
+  }
+
+  setDimensions() {
+    const { aspectRatio } = this.props;
+    const { parentWidth, parentHeight } = this.getParentDimensions();
+    const isFullWidth = this.shouldBeFullWidth();
+    const width = isFullWidth ? parentWidth : parentHeight / aspectRatio;
+    const height = isFullWidth ? parentWidth * aspectRatio : parentHeight;
     this.setState({ dimensions: { width, height } });
   }
 

--- a/lib/VideoPlayer.js
+++ b/lib/VideoPlayer.js
@@ -12,6 +12,7 @@ export default class VideoPlayer extends Component {
   static get defaultProps() {
     return {
       aspectRatio: 9 / 16,
+      fullWidth: false,
       fullWidthAt: 0,
       options: {
         preload: 'auto',
@@ -29,6 +30,7 @@ export default class VideoPlayer extends Component {
   static get propTypes() {
     return {
       aspectRatio: PropTypes.number,
+      fullWidth: PropTypes.bool,
       fullWidthAt: PropTypes.number,
       options: PropTypes.shape({
         bigPlayButton: PropTypes.bool,
@@ -91,7 +93,9 @@ export default class VideoPlayer extends Component {
     parentHeight = parentHeight - padding.top - padding.bottom;
     const aspectRatio = this.props.aspectRatio;
     let width, height;
-    if ((parentWidth * aspectRatio <= parentHeight) ||
+    if (
+      this.props.fullWidth ||
+      (parentWidth * aspectRatio <= parentHeight) ||
       (this.props.fullWidthAt && window.innerWidth < this.props.fullWidthAt)
     ) {
       width = parentWidth;

--- a/lib/VideoPlayer.scss
+++ b/lib/VideoPlayer.scss
@@ -65,6 +65,21 @@ $primary-background-color: rgba(0, 0, 0, 0.3);
   order: 3;
 }
 
+.vjs-volume-panel.vjs-volume-panel-horizontal {
+  align-items: center;
+
+  & .vjs-volume-control.vjs-control.vjs-volume-horizontal {
+    &, &:hover, .video-js .vjs-volume-panel .vjs-mute-control:hover ~ & {
+      height: auto !important;
+    }
+
+    & .vjs-volume-bar {
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+  }
+}
+
 // Vertical volume container
 .video-js .vjs-volume-vertical {
   background-color: rgba(0, 0, 0, 0.5);


### PR DESCRIPTION
### Changes:
- Add `fullWidth` flag, in the case where the video should always take the full width of the parent regardless of screen size
- Inline volume was always rendering off center for me (not sure why as this style comes directly from vjs :woman_shrugging:), I added some styles that regrettably wound up in a specificity battle, but as far as I can tell it fixed the issue.