### PR TITLE
Prevent Tooltip Wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.2.2] - 2020-12-07
+
+### Changed
+ * Prevent time tooltips from wrapping
+
 ## [2.2.0] - 2020-10-05
 
 ### Added

--- a/lib/player.scss
+++ b/lib/player.scss
@@ -112,6 +112,7 @@ $primary-background-color: rgba(0, 0, 0, 0.3);
   font-size: 1.2rem;
   padding: 0.2em 1em;
   min-width: 5rem;
+  white-space: nowrap;
 }
 
 // Progress bar

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@articulate/orson",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "React video component with some Articulate flavor",
   "scripts": {
     "build": "npm run clean && npm run build:js && npm run build:styles",


### PR DESCRIPTION
When displaying 4 digit times (anything over 10 minutes) on 360-review, tooltips would wrap. 

![image](https://user-images.githubusercontent.com/186246/101411220-3895cc80-38a6-11eb-9644-5f78789f7dbe.png)

These tooltips should never wrap, so we've added `nowrap`

articulate/360-frontend#3066
