### PR TITLE
A11y: Update Player With New `a11y` Styles

### DIFF
--- a/lib/a11y.scss
+++ b/lib/a11y.scss
@@ -1,47 +1,12 @@
 $a11y-background-color: rgba(0, 0, 0, 0.67);
 
-$a11y-glow-start-color: rgba(255, 255, 255, 0.5);
-$a11y-glow-end-color: rgba(255, 255, 255, 0.1);
-
-@mixin focus-glow {
-  background-color: $a11y-background-color;
-  text-shadow: none;
-  overflow: visible; // for ie11
-
-  &::before,
-  &::after {
-    content: '';
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    width: 4px;
-    z-index: 0;
-  }
-
-  &::before {
-    background: linear-gradient(-90deg, $a11y-glow-start-color, $a11y-glow-end-color);
-    left: -4px;
-  }
-
-  &::after {
-    background: linear-gradient(90deg, $a11y-glow-start-color, $a11y-glow-end-color);
-    right: -4px;
-  }
-}
-
-@mixin volume-control-glow {
-  border-radius: 3px;
-  box-shadow: 0 0 4px #fff;
-
-  &::before,
-  &::after {
-    content: none;
-  }
-}
-
 .video-a11y {
   .vjs-big-play-button {
     background-color: $a11y-background-color;
+    margin: 0;
+    transform: translate(-50%, -50%);
+    transition: none !important;
+    transition: background-color 0.4s !important;
   }
 
   .vjs-paused {
@@ -56,7 +21,9 @@ $a11y-glow-end-color: rgba(255, 255, 255, 0.1);
   .vjs-big-play-button:focus,
   &:hover .vjs-big-play-button {
     background-color: rgba(0, 0, 0, 0.85);
-    box-shadow: 0 0 4px #fff;
+    width: 10.4rem;
+    height: 10.4rem;
+    border: 0.3rem solid white;
   }
 
   .vjs-control-bar {
@@ -71,36 +38,7 @@ $a11y-glow-end-color: rgba(255, 255, 255, 0.1);
       height: 4px;
     }
 
-    &::before {
-      top: -4px;
-      background: linear-gradient(0deg, $a11y-glow-start-color, $a11y-glow-end-color);
-    }
-
-    &::after {
-      bottom: -4px;
-      background: linear-gradient(180deg, $a11y-glow-start-color, $a11y-glow-end-color);
-    }
-
     .vjs-control {
-      &:focus,
-      &:hover {
-        @include focus-glow;
-      }
-
-      &.vjs-progress-control.focus-within,
-      &.vjs-playback-rate.focus-within,
-      &.vjs-volume-panel.focus-within,
-      &.vjs-subs-caps-button.focus-within {
-        @include focus-glow;
-      }
-
-      &.vjs-progress-control:focus-within,
-      &.vjs-playback-rate:focus-within,
-      &.vjs-volume-panel:focus-within,
-      &.vjs-subs-caps-button:focus-within {
-        @include focus-glow;
-      }
-
       &:first-child {
         margin-left: 0;
 
@@ -147,15 +85,6 @@ $a11y-glow-end-color: rgba(255, 255, 255, 0.1);
       }
 
       .vjs-volume-control {
-        &:hover,
-        &.focus-within {
-          @include volume-control-glow;
-        }
-
-        &:focus-within {
-          @include volume-control-glow;
-        }
-
         &.vjs-volume-horizontal {
           margin-left: 0.5em;
           height: 3em;
@@ -178,7 +107,7 @@ $a11y-glow-end-color: rgba(255, 255, 255, 0.1);
     }
 
     .vjs-menu-button-popup .vjs-menu .vjs-menu-content {
-      background-color: rgba(0, 0, 0, 0.9);
+      background-color: $a11y-background-color;
     }
   }
 }


### PR DESCRIPTION
This PR implements the new styles to be used with the `video-a11y` CSS class. 

## Things of Interest
This will need a couple passes through, at the least QA, due to the integration of this library. The first pass is just to verify the functionality. While the second will occur after the release of this code to npm, to verify the integration of the release to [the frontend PR][pr]

## Links
* [issue][issue]
* [frontend-pr][pr]

## Testing
To play with the styles implemented in this PR, they have been integrated into [this frontend PR][pr] and should be played with on that branch. As such testing instructions are on that PR.

[pr]: https://github.com/articulate/rise-frontend/pull/2668
[issue]: https://github.com/articulate/rise-frontend/issues/2665