### PR TITLE
README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Orson [![NSP Status](https://nodesecurity.io/orgs/articulate/projects/b1ab5729-5cba-4672-a2f9-2f047db32b86/badge)](https://nodesecurity.io/orgs/articulate/projects/b1ab5729-5cba-4672-a2f9-2f047db32b86)
+# Orson
 
 An Articulate flavored React component video player.
 


### PR DESCRIPTION
- remove nodesecurity.io as it has been shut down
- dependabot security alerts and updates are enabled on this repo